### PR TITLE
Update requirements, fix issues for Mac

### DIFF
--- a/requirements_client.txt
+++ b/requirements_client.txt
@@ -3,4 +3,4 @@ PyYAML==5.1
 requests==2.23
 msgpack-numpy==0.4.5
 pyzmq==19.0.0
-opencv-python==3.4.9.33
+opencv-python==3.4.5.20


### PR DESCRIPTION
The current requirements demand Mac Catalina OS.
By changing the numpy to 3.4.5.20, we can fix the compatibility issues for all MacOS version.